### PR TITLE
Add ability to list applications by service_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- List Applications by Service
+
 ### Changed
 
 ## [0.1.2] - 2016-03-16
@@ -22,5 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Application Plans List & Create
 - Usage Limits List, Create & Delete
 
-[Unreleased]: https://github.com/3scale/3scale-api-ruby/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/3scale/3scale-api-ruby/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/3scale/3scale-api-ruby/releases/tag/v0.1.2
+[0.1.1]: https://github.com/3scale/3scale-api-ruby/releases/tag/v0.1.1
 [0.1.0]: https://github.com/3scale/3scale-api-ruby/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- List Applications by Service
+- Applications List & List by Service
 
 ### Changed
 

--- a/lib/3scale/api/client.rb
+++ b/lib/3scale/api/client.rb
@@ -28,8 +28,9 @@ module ThreeScale
       # @api public
       # @return [Array<Hash>]
       # @param [Fixnum] service_id Service ID
-      def list_applications(service_id)
-        response = http_client.get("/admin/api/applications", params: { service_id: service_id })
+      def list_applications(service_id: nil)
+        params = service_id ? { service_id: service_id } : nil
+        response = http_client.get("/admin/api/applications", params: params)
         extract(collection: 'applications', entity: 'application', from: response)
       end
 

--- a/lib/3scale/api/client.rb
+++ b/lib/3scale/api/client.rb
@@ -26,6 +26,14 @@ module ThreeScale
       end
 
       # @api public
+      # @return [Array<Hash>]
+      # @param [Fixnum] service_id Service ID
+      def list_applications(service_id)
+        response = http_client.get("/admin/api/applications", params: { service_id: service_id })
+        extract(collection: 'applications', entity: 'application', from: response)
+      end
+
+      # @api public
       # @return [Hash]
       # @param [Hash] attributes Service Attributes
       # @option attributes [String] :name Service Name

--- a/lib/3scale/api/http_client.rb
+++ b/lib/3scale/api/http_client.rb
@@ -30,20 +30,20 @@ module ThreeScale
         @format = format
       end
 
-      def get(path)
-        parse @http.get("#{path}.#{format}", headers)
+      def get(path, params: nil)
+        parse @http.get(format_path_n_query(path, params), headers)
       end
 
-      def patch(path, body: )
-        parse @http.patch("#{path}.#{format}", serialize(body), headers)
+      def patch(path, body: , params: nil)
+        parse @http.patch(format_path_n_query(path, params), serialize(body), headers)
       end
 
-      def post(path, body: )
-        parse @http.post("#{path}.#{format}", serialize(body), headers)
+      def post(path, body: , params: nil)
+        parse @http.post(format_path_n_query(path, params), serialize(body), headers)
       end
 
-      def delete(path)
-        parse @http.delete("#{path}.#{format}", headers)
+      def delete(path, params: nil)
+        parse @http.delete(format_path_n_query(path, params), headers)
       end
 
       # @param [::Net::HTTPResponse] response
@@ -79,6 +79,13 @@ module ThreeScale
 
       def debug?
         ENV.fetch('3SCALE_DEBUG', '0') == '1'
+      end
+
+      # Helper to create a string representing a path plus a query string
+      def format_path_n_query(path, params)
+        path = "#{path}.#{format}"
+        path << "?#{URI.encode_www_form(params)}" unless params.nil?
+        path
       end
 
       module JSONParser

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -44,6 +44,13 @@ RSpec.describe ThreeScale::API::Client do
     end
   end
 
+  context '#list_applications' do
+    it do
+      expect(http_client).to receive(:get).with('/admin/api/applications').and_return('applications' => [])
+      expect(client.list_applications).to eq([])
+    end
+  end
+
   context '#list_mapping_rules' do
     it do
       expect(http_client).to receive(:get)

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -46,8 +46,17 @@ RSpec.describe ThreeScale::API::Client do
 
   context '#list_applications' do
     it do
-      expect(http_client).to receive(:get).with('/admin/api/applications').and_return('applications' => [])
+      expect(http_client).to receive(:get)
+                                 .with('/admin/api/applications', params: nil)
+                                 .and_return('applications' => [])
       expect(client.list_applications).to eq([])
+    end
+
+    it 'filters by service'do
+      expect(http_client).to receive(:get)
+                                 .with('/admin/api/applications', params: { service_id: 42 })
+                                 .and_return('applications' => [])
+      expect(client.list_applications(service_id: 42)).to eq([])
     end
   end
 

--- a/spec/api/http_client_spec.rb
+++ b/spec/api/http_client_spec.rb
@@ -34,12 +34,12 @@ RSpec.describe ThreeScale::API::HttpClient do
 
   describe '#post' do
     let!(:stub) {
-      stub_request(:post,  "https://:#{provider_key}@#{admin_domain}/foo.json")
+      stub_request(:post,  "https://:#{provider_key}@#{admin_domain}/foo.json?one=1&two=2")
           .with(body: '{"bar":"baz"}')
           .and_return(body: '{"foo":"bar"}')
     }
 
-    subject { client.post('/foo', body: {bar: 'baz'}) }
+    subject { client.post('/foo', body: {bar: 'baz'}, params: { one: 1, two: 2 }) }
 
     it 'makes a request' do
       is_expected.to be
@@ -53,12 +53,12 @@ RSpec.describe ThreeScale::API::HttpClient do
 
   describe '#patch' do
     let!(:stub) {
-      stub_request(:patch,  "https://:#{provider_key}@#{admin_domain}/foo.json")
+      stub_request(:patch,  "https://:#{provider_key}@#{admin_domain}/foo.json?one=1&two=2")
           .with(body: '{"bar":"baz"}')
           .and_return(body: '{"foo":"bar"}')
     }
 
-    subject { client.patch('/foo', body: {bar: 'baz'}) }
+    subject { client.patch('/foo', body: {bar: 'baz'}, params: { one: 1, two: 2 }) }
 
     it 'makes a request' do
       is_expected.to be
@@ -73,11 +73,11 @@ RSpec.describe ThreeScale::API::HttpClient do
 
   describe '#delete' do
     let!(:stub) {
-      stub_request(:delete,  "https://:#{provider_key}@#{admin_domain}/foo.json")
+      stub_request(:delete,  "https://:#{provider_key}@#{admin_domain}/foo.json?one=1&two=2")
           .and_return(body: '{"foo":"bar"}')
     }
 
-    subject { client.delete('/foo') }
+    subject { client.delete('/foo', params: { one: 1, two: 2 }) }
 
     it 'makes a request' do
       is_expected.to be

--- a/spec/integration/service_spec.rb
+++ b/spec/integration/service_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe 'Service API', type: :integration do
     it { is_expected.to include('credentials_location' => 'headers') }
   end
 
+  context '#list_applications' do
+    it { expect(client.list_applications.length).to be >= 1 }
+  end
+
   context '#create_mapping_rules' do
     subject(:create) { client.create_mapping_rule(service_id,
                                                     http_method: 'PUT',


### PR DESCRIPTION
This also introduces a `params` named argument in `http_client` to allow extra query string parameters.