### PR TITLE
Minor renaming and fix of error handling from admin portal

### DIFF
--- a/lib/three_scale_api/tools.rb
+++ b/lib/three_scale_api/tools.rb
@@ -52,8 +52,8 @@ module ThreeScaleApi
     #
     # @param [Hash] response Response from server
     def self.check_response(response)
-      if (response.is_a? Hash) && !response['error'].nil?
-        raise APIResponseError.new(response), response['error']
+      if (response.is_a? Hash) && (response['error'] || response['errors'])
+        raise APIResponseError.new(response), (response['error'] || response['errors'])
       end
       response
     end

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -3,7 +3,7 @@
 require_relative './shared_tests_config'
 
 # Shared test for Crud operations
-shared_examples :crud_resource do
+RSpec.shared_examples :crud_resource do
   context 'Create' do
     it 'should create resource' do
       expect(@resource).to res_include(base_attr => @name)
@@ -73,7 +73,7 @@ end
 
 # Shared example for all plan resources and managers.
 # It runs shared crud tests and List all with get and set default plan
-shared_examples :plan_resource do
+RSpec.shared_examples :plan_resource do
   let(:base_attr) { 'name' }
   let(:update_params) do
     { param: 'state', value: 'published' }
@@ -106,7 +106,7 @@ shared_examples :plan_resource do
   end
 end
 
-shared_examples :user_resource do
+RSpec.shared_examples :user_resource do
   let(:base_attr) { 'username' }
   let(:update_params) do
     new_name = @name + '-updated@example.com'


### PR DESCRIPTION
Renamed errors to error and
removed Rspec prefix

Signed-off-by: Peter Stanko <pstanko@redhat.com>