### PR TITLE
Convert symbols to string when used as keys to access entity properties

### DIFF
--- a/lib/three_scale_api/resources/default.rb
+++ b/lib/three_scale_api/resources/default.rb
@@ -40,7 +40,7 @@ module ThreeScaleApi
       # @param [String] key Name of the property
       # @return [object] Value of the property
       def [](key)
-        entity[key]
+        entity[key.to_s]
       end
 
       # @api public
@@ -50,7 +50,7 @@ module ThreeScaleApi
       # @param [String] value Value of the property
       # @return [object] Value of the property
       def []=(key, value)
-        entity[key] = value
+        entity[key.to_s] = value
       end
 
       # @api public


### PR DESCRIPTION
Here I can ask. What is a best practice to use symbol and strings as a keys in hash.
I have found that it is not possible to use them interchangeably.

Signed-off-by: Peter Stanko <pstanko@redhat.com>