### PR TITLE
Verify ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ PROVIDER_KEY=abc123
 SERVICE_ID=12345
 METRIC_ID=12345 # should be a numeric value, not the system name
 APPLICATION_PLAN_ID=12345
+VERIFY_SSL=true (by default true)
 ```
 
 **Note:** for the tests to pass the following requirements need to be met:

--- a/lib/3scale/api.rb
+++ b/lib/3scale/api.rb
@@ -5,9 +5,10 @@ module ThreeScale
     autoload :Client, '3scale/api/client'
     autoload :HttpClient, '3scale/api/http_client'
 
-    def self.new(endpoint:, provider_key:)
+    def self.new(endpoint:, provider_key:, verify_ssl: true)
       http_client = HttpClient.new(endpoint: endpoint,
-                                   provider_key: provider_key)
+                                   provider_key: provider_key,
+                                   verify_ssl: verify_ssl)
       Client.new(http_client)
     end
   end

--- a/lib/3scale/api/http_client.rb
+++ b/lib/3scale/api/http_client.rb
@@ -1,18 +1,20 @@
 require 'json'
 require 'uri'
 require 'net/http'
+require 'openssl'
 
 module ThreeScale
   module API
     class HttpClient
       attr_reader :endpoint, :admin_domain, :provider_key, :headers, :format
 
-      def initialize(endpoint:, provider_key:, format: :json)
+      def initialize(endpoint:, provider_key:, format: :json, verify_ssl: true)
         @endpoint = URI(endpoint).freeze
         @admin_domain = @endpoint.host.freeze
         @provider_key = provider_key.freeze
         @http = Net::HTTP.new(admin_domain, @endpoint.port)
         @http.use_ssl = @endpoint.is_a?(URI::HTTPS)
+        @http.verify_mode = OpenSSL::SSL::VERIFY_NONE unless verify_ssl
 
         @headers = {
           'Accept' => "application/#{format}",

--- a/spec/integration/account_spec.rb
+++ b/spec/integration/account_spec.rb
@@ -5,8 +5,12 @@ RSpec.describe 'Account API', type: :integration do
   let(:provider_key) { ENV.fetch('PROVIDER_KEY') }
   let(:service_id)   { ENV.fetch('SERVICE_ID').to_i }
   let(:application_plan_id) { ENV.fetch('APPLICATION_PLAN_ID').to_i }
+  let(:verify_ssl) { !(ENV.fetch('VERIFY_SSL', 'true').to_s =~ /(true|t|yes|y|1)$/i).nil? }
 
-  subject(:client) { ThreeScale::API.new(endpoint: endpoint, provider_key: provider_key) }
+  subject(:client) do
+    ThreeScale::API.new(endpoint: endpoint, provider_key: provider_key,
+                        verify_ssl: verify_ssl)
+  end
 
   context '#signup' do
     let(:name) { SecureRandom.hex(14) }

--- a/spec/integration/service_spec.rb
+++ b/spec/integration/service_spec.rb
@@ -6,8 +6,12 @@ RSpec.describe 'Service API', type: :integration do
   let(:service_id)   { ENV.fetch('SERVICE_ID').to_i }
   let(:metric_id) { ENV.fetch('METRIC_ID').to_i }
   let(:application_plan_id) { ENV.fetch('APPLICATION_PLAN_ID').to_i }
+  let(:verify_ssl) { !(ENV.fetch('VERIFY_SSL', 'true').to_s =~ /(true|t|yes|y|1)$/i).nil? }
 
-  subject(:client) { ThreeScale::API.new(endpoint: endpoint, provider_key: provider_key) }
+  subject(:client) do
+    ThreeScale::API.new(endpoint: endpoint, provider_key: provider_key,
+                        verify_ssl: verify_ssl)
+  end
 
   context '#list_services' do
     it { expect(client.list_services.length).to be >= 1 }


### PR DESCRIPTION
Enable configuration of http client for verifying ssl certificates. 

If ssl verify enabled, the client cannot be used in testing environments or when trusted certificates have not been installed. 

By default, if nothing configured, ssl certificates are verified, keeping backwards compatibility.

