### PR TITLE
http_client: raise error when unexpected response like 503

### DIFF
--- a/lib/3scale/api/http_client.rb
+++ b/lib/3scale/api/http_client.rb
@@ -57,14 +57,27 @@ module ThreeScale
         case response
         when Net::HTTPUnprocessableEntity, Net::HTTPSuccess then parser.decode(response.body)
         when Net::HTTPForbidden then forbidden!(response)
-        else "Can't handle #{response.inspect}"
+        when Net::HTTPNotFound then notfound!(response)
+        else unexpected!(response.inspect)
         end
       end
 
       class ForbiddenError < StandardError; end
 
+      class UnexpectedResponseError < StandardError; end
+
+      class NotFoundError < StandardError; end
+
       def forbidden!(response)
         raise ForbiddenError, response
+      end
+
+      def notfound!(response)
+        raise NotFoundError, response
+      end
+
+      def unexpected!(response)
+        raise UnexpectedResponseError, response
       end
 
       def serialize(body)

--- a/spec/integration/service_spec.rb
+++ b/spec/integration/service_spec.rb
@@ -65,7 +65,12 @@ RSpec.describe 'Service API', type: :integration do
 
     it { expect(create).to include('http_method' => 'PUT') }
 
-    after { client.delete_mapping_rule(service_id, create.fetch('id')) }
+    after do
+      begin
+        client.delete_mapping_rule(service_id, create.fetch('id'))
+      rescue ThreeScale::API::HttpClient::NotFoundError
+      end
+    end
 
     context '#list_mapping_rules' do
       before { create }


### PR DESCRIPTION
Client users are expecting ruby data structure object parsed from `json`response or error raised on any event like http status code not 200, parsing error, not valid credentials, etc...

On response `Net::HTTPServiceUnavailable 503 Service Unavailable `, the client was neither returning object not raising error. It was returning `String`.

