### PR TITLE
find application by service_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 /spec/reports/
 /spec/examples.txt
 /tmp/
+/vendor/
 .env

--- a/lib/3scale/api/client.rb
+++ b/lib/3scale/api/client.rb
@@ -53,8 +53,13 @@ module ThreeScale
       # @param [Fixnum] id Application ID
       # @param [String] user_key Application User Key
       # @param [String] application_id Application app_id
-      def find_application(id: nil, user_key: nil, application_id: nil)
-        params = { application_id: id, user_key: user_key, app_id: application_id }.reject { |_, value| value.nil? }
+      def find_application(id: nil, user_key: nil, application_id: nil, service_id: nil)
+        params = {
+          application_id: id,
+          user_key: user_key,
+          app_id: application_id,
+          service_id: service_id,
+        }.compact
         response = http_client.get('/admin/api/applications/find', params: params)
         extract(entity: 'application', from: response)
       end

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -168,6 +168,13 @@ RSpec.describe ThreeScale::API::Client do
       expect(client.find_application(user_key: 'hex')).to eq('user_key' => 'hex')
     end
 
+    it 'finds by user_key and service_id' do
+      expect(http_client).to receive(:get)
+        .with('/admin/api/applications/find', params: { user_key: 'hex', service_id: 100 })
+        .and_return('application' => { 'user_key' => 'hex' })
+      expect(client.find_application(user_key: 'hex', service_id: 100)).to eq('user_key' => 'hex')
+    end
+
     it 'finds by app_id' do
       expect(http_client).to receive(:get)
         .with('/admin/api/applications/find', params: { app_id: 'hex' })


### PR DESCRIPTION
`find_application` adds `service_id` criteria param and keeps backward compatibility.