### PR TITLE
Replace use of uuid with random hex of 16 chars for the service names

### DIFF
--- a/spec/integration/account_spec.rb
+++ b/spec/integration/account_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Account API', type: :integration do
     context 'on app_id, app_key service' do
       let(:service) do
         @apiclient.create_service(
-          'name' => "3scalerubytest#{SecureRandom.uuid}",
+          'name' => "#{SecureRandom.hex(16)}",
           'backend_version': '2'
         )
       end
@@ -77,7 +77,7 @@ RSpec.describe 'Account API', type: :integration do
       end
       let(:application_plan) do
         @apiclient.create_application_plan(service['id'],
-                                           'name' => "3scale ruby test #{SecureRandom.uuid}")
+                                           'name' => "#{SecureRandom.hex(16)}")
       end
       let(:app_id) { SecureRandom.hex(14) }
       let!(:application) do

--- a/spec/integration/service_spec.rb
+++ b/spec/integration/service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Service API', type: :integration do
   end
 
   context '#create_service' do
-    let(:name) { "3scale ruby test #{SecureRandom.uuid}" }
+    let(:name) { "#{SecureRandom.hex(16)}" }
     subject(:response) { client.create_service('name' => name) }
 
     after :each do
@@ -27,7 +27,7 @@ RSpec.describe 'Service API', type: :integration do
   end
 
   context '#update_service' do
-    let(:name) { "3scale ruby test #{SecureRandom.uuid}" }
+    let(:name) { "#{SecureRandom.hex(16)}" }
     subject(:response) { client.update_service(@service_test['id'], 'name' => name) }
 
     it { is_expected.to include('name' => name) }
@@ -151,7 +151,7 @@ RSpec.describe 'Service API', type: :integration do
   end
 
   context '#delete_service' do
-    let(:service_name) { "3scale ruby test #{SecureRandom.uuid}" }
+    let(:service_name) { "#{SecureRandom.hex(16)}" }
     let(:new_service) { client.create_service name: service_name }
 
     it 'service is deleted' do

--- a/spec/shared_contexts.rb
+++ b/spec/shared_contexts.rb
@@ -11,10 +11,10 @@ RSpec.shared_context :integration_test_context do
     @verify_ssl = !(ENV.fetch('VERIFY_SSL', 'true').to_s =~ /(true|t|yes|y|1)$/i).nil?
     @apiclient = ThreeScale::API.new(endpoint: @endpoint, provider_key: @provider_key,
                                      verify_ssl: @verify_ssl)
-    @service_test = @apiclient.create_service('name' => "3scalerubytest#{SecureRandom.uuid}")
+    @service_test = @apiclient.create_service('name' => "#{SecureRandom.hex(16)}")
     account_name = SecureRandom.hex(14)
     @account_test = @apiclient.signup(name: account_name, username: account_name)
-    @application_plan_test = @apiclient.create_application_plan(@service_test['id'], 'name' => "3scale ruby test #{SecureRandom.uuid}")
+    @application_plan_test = @apiclient.create_application_plan(@service_test['id'], 'name' => "#{SecureRandom.hex(16)}")
     app_id = SecureRandom.hex(14)
     @application_test = @apiclient.create_application(@account_test['id'],
                                                       plan_id: @application_plan_test['id'],
@@ -35,8 +35,9 @@ RSpec.shared_context :integration_test_context do
   end
 
   after :context do
-    @apiclient.delete_application(@account_test['id'], @application_test['id'])
-    @apiclient.delete_service(@service_test['id'])
-    @apiclient.delete_account(@account_test['id'])
+    return if @apiclient == nil
+    @apiclient.delete_application(@account_test['id'], @application_test['id']) if @account_test != nil && @application_test != nil
+    @apiclient.delete_service(@service_test['id']) if @service_test
+    @apiclient.delete_account(@account_test['id']) if @account_test
   end
 end


### PR DESCRIPTION
API now has a resticted length on service names causing test failures
due to length of uuid generated. This avoids the failures by using a 16char 
random hex number with no text prefixed.