### PR TITLE
coverage report no pushed on nightly workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,26 @@ commands:
           command: |
             bundle exec rake
 jobs:
+  ruby-262-unittest-coverage:
+    docker:
+      - image: circleci/ruby:2.6.2
+    working_directory: ~/repo
+    environment:
+      COVERAGE: true
+    steps:
+      - checkout
+      - unittests
+
+  ruby-270-unittest-coverage:
+    docker:
+      - image: circleci/ruby:2.7.0
+    working_directory: ~/repo
+    environment:
+      COVERAGE: true
+    steps:
+      - checkout
+      - unittests
+
   ruby-262-unittest:
     docker:
       - image: circleci/ruby:2.6.2
@@ -80,18 +100,18 @@ workflows:
   version: 2
   tests:
     jobs:
-      - ruby-262-unittest:
+      - ruby-262-unittest-coverage:
           filters:
             <<: *tag-trigger
           context: autotestaccount
-      - ruby-270-unittest:
+      - ruby-270-unittest-coverage:
           filters:
             <<: *tag-trigger
           context: autotestaccount
       - push-rubygems:
           requires:
-            - ruby-262-unittest
-            - ruby-270-unittest
+            - ruby-262-unittest-coverage
+            - ruby-270-unittest-coverage
           filters:
             <<: *tag-trigger
             branches:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'yaml'
 # Codecov
 require 'simplecov'
 SimpleCov.start
-if ENV['CI'] == 'true'
+if ENV['COVERAGE'] == 'true'
   require 'codecov'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end


### PR DESCRIPTION
Coverage report was pushed to codecov.io when running the nightly workflow. 

codecov.io started complaining about 
```
Too many uploads to this commit
```
And the job failed.

It does not make sense to upload codecov in nightly as code  has not been changed. Nightly is meant to test integration with SaaS.

Codecov will only be activated in regular branch and PR workflows