### PR TITLE
enable keep alive connections

### DIFF
--- a/lib/3scale/api.rb
+++ b/lib/3scale/api.rb
@@ -6,10 +6,12 @@ module ThreeScale
     autoload :Client, '3scale/api/client'
     autoload :HttpClient, '3scale/api/http_client'
 
-    def self.new(endpoint:, provider_key:, verify_ssl: true)
+    def self.new(endpoint:, provider_key:, verify_ssl: true, keep_alive: false)
       http_client = HttpClient.new(endpoint: endpoint,
                                    provider_key: provider_key,
-                                   verify_ssl: verify_ssl)
+                                   verify_ssl: verify_ssl,
+                                   keep_alive: keep_alive,
+                                  )
       Client.new(http_client)
     end
   end

--- a/lib/3scale/api/http_client.rb
+++ b/lib/3scale/api/http_client.rb
@@ -6,9 +6,9 @@ require 'openssl'
 module ThreeScale
   module API
     class HttpClient
-      attr_reader :endpoint, :admin_domain, :provider_key, :headers, :format
+      attr_reader :endpoint, :admin_domain, :provider_key, :headers, :format, :keep_alive
 
-      def initialize(endpoint:, provider_key:, format: :json, verify_ssl: true)
+      def initialize(endpoint:, provider_key:, format: :json, verify_ssl: true, keep_alive: false)
         @endpoint = URI(endpoint).freeze
         @admin_domain = @endpoint.host.freeze
         @provider_key = provider_key.freeze
@@ -30,25 +30,37 @@ module ThreeScale
         @headers.freeze
 
         @format = format
+
+        @keep_alive = keep_alive
       end
 
       def get(path, params: nil)
+        @http.start if keep_alive && !@http.started?
+
         parse @http.get(format_path_n_query(path, params), headers)
       end
 
       def patch(path, body:, params: nil)
+        @http.start if keep_alive && !@http.started?
+
         parse @http.patch(format_path_n_query(path, params), serialize(body), headers)
       end
 
       def post(path, body:, params: nil)
+        @http.start if keep_alive && !@http.started?
+
         parse @http.post(format_path_n_query(path, params), serialize(body), headers)
       end
 
       def put(path, body: nil, params: nil)
+        @http.start if keep_alive && !@http.started?
+
         parse @http.put(format_path_n_query(path, params), serialize(body), headers)
       end
 
       def delete(path, params: nil)
+        @http.start if keep_alive && !@http.started?
+
         parse @http.delete(format_path_n_query(path, params), headers)
       end
 

--- a/spec/api/http_client_spec.rb
+++ b/spec/api/http_client_spec.rb
@@ -183,4 +183,105 @@ RSpec.describe ThreeScale::API::HttpClient do
       expect { subject }.to raise_error(ThreeScale::API::HttpClient::NotFoundError, /bar/)
     end
   end
+
+  describe 'keep alive connections' do
+    let(:client) do
+      described_class.new(endpoint: 'https://foo-admin.3scale.net',
+                          provider_key: 'some-key', keep_alive: true,
+                         )
+    end
+
+    it do
+      expect(client.keep_alive).to be_truthy
+    end
+
+    describe '#get' do
+      let!(:stub) do
+        stub_request(:get, "https://#{admin_domain}/foo.json").and_return(body: '{"foo": "bar"}')
+      end
+
+      subject { client.get('/foo') }
+
+      it 'makes a request' do
+        is_expected.to be
+        expect(stub).to have_been_requested
+      end
+
+      it 'returns body' do
+        is_expected.to eq('foo' => 'bar')
+      end
+    end
+
+    describe '#patch' do
+      let!(:stub) do
+        stub_request(:patch,  "https://#{admin_domain}/foo.json")
+          .and_return(body: '{"foo":"bar"}')
+      end
+
+      subject { client.patch('/foo', body: nil) }
+
+      it 'makes a request' do
+        is_expected.to be
+        expect(stub).to have_been_requested
+      end
+
+      it 'returns body' do
+        is_expected.to eq('foo' => 'bar')
+      end
+    end
+
+    describe '#post' do
+      let!(:stub) do
+        stub_request(:post,  "https://#{admin_domain}/foo.json")
+          .and_return(body: '{"foo":"bar"}')
+      end
+
+      subject { client.post('/foo', body: nil) }
+
+      it 'makes a request' do
+        is_expected.to be
+        expect(stub).to have_been_requested
+      end
+
+      it 'returns body' do
+        is_expected.to eq('foo' => 'bar')
+      end
+    end
+
+    describe '#put' do
+      let!(:stub) do
+        stub_request(:put,  "https://#{admin_domain}/foo.json")
+          .and_return(body: '{"foo":"bar"}')
+      end
+
+      subject { client.put('/foo', body: nil) }
+
+      it 'makes a request' do
+        is_expected.to be
+        expect(stub).to have_been_requested
+      end
+
+      it 'returns body' do
+        is_expected.to eq('foo' => 'bar')
+      end
+    end
+
+    describe '#delete' do
+      let!(:stub) do
+        stub_request(:delete,  "https://#{admin_domain}/foo.json")
+          .and_return(body: '{"foo":"bar"}')
+      end
+
+      subject { client.delete('/foo') }
+
+      it 'makes a request' do
+        is_expected.to be
+        expect(stub).to have_been_requested
+      end
+
+      it 'returns body' do
+        is_expected.to eq('foo' => 'bar')
+      end
+    end
+  end
 end


### PR DESCRIPTION
For each 3scale Admin API call, the client was opening a new connection. For backwards compat, the default behavior will still be to open a new connection for each API call. But `keep_alive` new attr allows to keep connections open for multiple calls.